### PR TITLE
feat: draft helpers for e.g. fader with transfert tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "api": "jsdoc-to-readme --src src/*.js --heading-depth 2",
     "lint": "eslint index.js",
     "preversion": "npm run api && git commit -am 'docs: rebuild'  --allow-empty",
-    "test": "mocha tests/index.spec.js"
+    "test": "mocha"
   },
   "license": "BSD-3-Clause",
   "dependencies": {

--- a/src/fader-tables.js
+++ b/src/fader-tables.js
@@ -1,0 +1,72 @@
+export const sslFader = [-144.50,-140.98,-137.46,-133.94,-130.42,-126.90,-123.38,-119.85,-116.33,-112.81,-109.29,-105.77,-102.25,-98.73,-95.21,-91.69,-88.17,-84.65,-81.13,-77.60,-74.08,-70.56,-67.04,-63.52,-60.00,-59.69,-59.38,-59.06,-58.75,-58.44,-58.13,-57.81,-57.50,-57.19,-56.88,-56.56,-56.25,-55.94,-55.63,-55.31,-55.00,-54.69,-54.38,-54.06,-53.75,-53.44,-53.13,-52.81,-52.50,-52.19,-51.88,-51.56,-51.25,-50.94,-50.63,-50.31,-50.00,-49.69,-49.38,-49.06,-48.75,-48.44,-48.13,-47.81,-47.50,-47.19,-46.88,-46.56,-46.25,-45.94,-45.63,-45.31,-45.00,-44.69,-44.38,-44.06,-43.75,-43.44,-43.13,-42.81,-42.50,-42.19,-41.88,-41.56,-41.25,-40.94,-40.63,-40.31,-40.00,-39.84,-39.68,-39.52,-39.36,-39.20,-39.04,-38.88,-38.72,-38.56,-38.40,-38.24,-38.09,-37.93,-37.77,-37.61,-37.45,-37.29,-37.13,-36.97,-36.81,-36.65,-36.49,-36.33,-36.17,-36.01,-35.85,-35.69,-35.53,-35.37,-35.21,-35.05,-34.89,-34.73,-34.57,-34.41,-34.26,-34.10,-33.94,-33.78,-33.62,-33.46,-33.30,-33.14,-32.98,-32.82,-32.66,-32.50,-32.34,-32.18,-32.02,-31.86,-31.70,-31.54,-31.38,-31.22,-31.06,-30.90,-30.74,-30.59,-30.43,-30.27,-30.11,-29.95,-29.79,-29.63,-29.47,-29.31,-29.15,-28.99,-28.83,-28.67,-28.51,-28.35,-28.19,-28.03,-27.87,-27.71,-27.55,-27.39,-27.23,-27.07,-26.91,-26.76,-26.60,-26.44,-26.28,-26.12,-25.96,-25.80,-25.64,-25.48,-25.32,-25.16,-25.00,-24.84,-24.68,-24.52,-24.36,-24.20,-24.04,-23.88,-23.72,-23.56,-23.40,-23.24,-23.09,-22.93,-22.77,-22.61,-22.45,-22.29,-22.13,-21.97,-21.81,-21.65,-21.49,-21.33,-21.17,-21.01,-20.85,-20.69,-20.53,-20.37,-20.21,-20.05,-19.89,-19.73,-19.57,-19.41,-19.26,-19.10,-18.94,-18.78,-18.62,-18.46,-18.30,-18.14,-17.98,-17.82,-17.66,-17.50,-17.34,-17.18,-17.02,-16.86,-16.70,-16.54,-16.38,-16.22,-16.06,-15.90,-15.74,-15.59,-15.43,-15.27,-15.11,-14.95,-14.79,-14.63,-14.47,-14.31,-14.15,-13.99,-13.83,-13.67,-13.51,-13.35,-13.19,-13.03,-12.87,-12.71,-12.55,-12.39,-12.23,-12.07,-11.91,-11.76,-11.60,-11.44,-11.28,-11.12,-10.96,-10.80,-10.64,-10.48,-10.32,-10.16,-10.00,-9.92,-9.84,-9.75,-9.67,-9.59,-9.51,-9.43,-9.34,-9.26,-9.18,-9.10,-9.02,-8.93,-8.85,-8.77,-8.69,-8.61,-8.52,-8.44,-8.36,-8.28,-8.20,-8.11,-8.03,-7.95,-7.87,-7.79,-7.70,-7.62,-7.54,-7.46,-7.38,-7.30,-7.21,-7.13,-7.05,-6.97,-6.89,-6.80,-6.72,-6.64,-6.56,-6.48,-6.39,-6.31,-6.23,-6.15,-6.07,-5.98,-5.90,-5.82,-5.74,-5.66,-5.57,-5.49,-5.41,-5.33,-5.25,-5.16,-5.08,-5.00,-4.92,-4.84,-4.75,-4.67,-4.59,-4.51,-4.43,-4.34,-4.26,-4.18,-4.10,-4.02,-3.93,-3.85,-3.77,-3.69,-3.61,-3.52,-3.44,-3.36,-3.28,-3.20,-3.11,-3.03,-2.95,-2.87,-2.79,-2.70,-2.62,-2.54,-2.46,-2.38,-2.30,-2.21,-2.13,-2.05,-1.97,-1.89,-1.80,-1.72,-1.64,-1.56,-1.48,-1.39,-1.31,-1.23,-1.15,-1.07,-0.98,-0.90,-0.82,-0.74,-0.66,-0.57,-0.49,-0.41,-0.33,-0.25,-0.16,-0.08, 0.00, 0.08, 0.15, 0.23, 0.30, 0.38, 0.45, 0.53, 0.61, 0.68, 0.76, 0.83, 0.91, 0.98, 1.06, 1.14, 1.21, 1.29, 1.36, 1.44, 1.52, 1.59, 1.67, 1.74, 1.82, 1.89, 1.97, 2.05, 2.12, 2.20, 2.27, 2.35, 2.42, 2.50, 2.58, 2.65, 2.73, 2.80, 2.88, 2.95, 3.03, 3.11, 3.18, 3.26, 3.33, 3.41, 3.48, 3.56, 3.64, 3.71, 3.79, 3.86, 3.94, 4.02, 4.09, 4.17, 4.24, 4.32, 4.39, 4.47, 4.55, 4.62, 4.70, 4.77, 4.85, 4.92, 5.00, 5.15, 5.30, 5.45, 5.60, 5.74, 5.89, 6.04, 6.19, 6.34, 6.49, 6.64, 6.79, 6.94, 7.09, 7.23, 7.38, 7.53, 7.68, 7.83, 7.98, 8.13, 8.28, 8.43, 8.57, 8.72, 8.87, 9.02, 9.17, 9.32, 9.47, 9.62, 9.77, 9.91,10.06,10.21,10.36,10.51,10.66,10.81,10.96,11.11,11.26,11.40,11.55,11.70,11.85,12.00];
+
+// @todo - define how to properly put that in current folder / file organization
+
+// We want these two things transfert function paths:
+// 1. lin [audio realm]          -> db  -> norm position [gui realm]
+// 2. norm position [gui realm]  -> db  -> lin [audio realm]
+//
+// As we already got `decibelToLinear`` and `linearToDecibel`, then only the
+// dB value needs to be shared
+
+// GUI elements such as `sc-slider` could accept a tranfert table as property
+// e.g.
+// <sc-slider
+//   .transfertTable=${sslFader}
+//   // internally use `valueToPosition` to properly display the gui
+//   value="0"
+//   // internally use `positionToValue` to retreive proper dB
+//   @input=${e => console.log(e.detail.value)}
+// ></sc-slider>
+
+/**
+ * Return the normalized position (i.e. index normalized) of the value value
+ * into the given transfert table.
+ * Value is clamped to min and max value of the transfert table.
+ * Value value in between two transfertTable values are linearly interpolated.
+ * Given transfert table must be defined such as n + 1 > n
+ *
+ * @todo - naming `valueToNormIndex`?
+ * @todo - accept decreasing transfert table?
+ * @todo - check transfert table and store in reference in WeakSet so we check it
+ *  only once
+ */
+export function valueToPosition(value, transfertTable) {
+  // clamp given value to transfert table boundaries
+  const min = transfertTable[0];
+  const max = transfertTable[transfertTable.length - 1];
+  value = Math.min(max, Math.max(min, value));
+
+  // find normalized position
+  let position;
+
+  for (let i = 0; i < transfertTable.length - 1; i++) {
+    let prev = transfertTable[i];
+    let next = transfertTable[i + 1];
+
+    if (value >= prev && value <= next) {
+      const k = (value - prev) / (next - prev);
+      position = (i + k) / (transfertTable.length - 1);
+
+      break;
+    }
+  }
+
+  return position;
+}
+
+/**
+ * Return the (linearly interpolated) value from transfert table according to given
+ * noramlized position.
+ */
+export function positionToValue(position, transfertTable) {
+  // clamp given position
+  position = Math.min(1, Math.max(0, position));
+  const index = position * (transfertTable.length - 1);
+
+  const prev = transfertTable[Math.floor(index)];
+  const next = transfertTable[Math.ceil(index)];
+  const k = index - Math.floor(index);
+
+  return prev + (next - prev) * k;
+}

--- a/tests/fader-tables.spec.js
+++ b/tests/fader-tables.spec.js
@@ -1,0 +1,88 @@
+import { assert } from 'chai';
+import { valueToPosition, positionToValue } from '../src/fader-tables.js';
+
+const transfertTable = [0, 0.25, 1];
+
+describe('# fader-tables', () => {
+  describe('valueToPosition(value, transfertTable)', () => {
+    it(`should work`, () => {
+      {
+        const res = valueToPosition(0, transfertTable);
+        assert.equal(res, 0);
+      }
+
+      {
+        const res = valueToPosition(1, transfertTable);
+        assert.equal(res, 1);
+      }
+
+      {
+        const res = valueToPosition(0.25, transfertTable);
+        assert.equal(res, 0.5);
+      }
+
+      {
+        const res = valueToPosition(0.125, transfertTable);
+        assert.equal(res, 0.25);
+      }
+
+      {
+        const res = valueToPosition(0.625, transfertTable);
+        assert.equal(res, 0.75);
+      }
+    });
+
+    it(`should clamp to table boundaries`, () => {
+      {
+        const res = valueToPosition(-1, transfertTable);
+        assert.equal(res, 0);
+      }
+
+      {
+        const res = valueToPosition(2, transfertTable);
+        assert.equal(res, 1);
+      }
+    });
+  });
+
+  describe('positionToValue(value, transfertTable)', () => {
+    it(`should work`, () => {
+      {
+        const res = positionToValue(0, transfertTable);
+        assert.equal(res, 0);
+      }
+
+      {
+        const res = positionToValue(1, transfertTable);
+        assert.equal(res, 1);
+      }
+
+      {
+        const res = positionToValue(0.5, transfertTable);
+        assert.equal(res, 0.25);
+      }
+
+      {
+        const res = positionToValue(0.25, transfertTable);
+        assert.equal(res, 0.125);
+      }
+
+      {
+        const res = positionToValue(0.75, transfertTable);
+        assert.equal(res, 0.625);
+      }
+    });
+
+    it(`should clamp to table boundaries`, () => {
+      {
+        const res = positionToValue(-1, transfertTable);
+        assert.equal(res, 0);
+      }
+
+      {
+        const res = positionToValue(2, transfertTable);
+        assert.equal(res, 1);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Hey @etiennedemoulin and @jipodine 

I just drafted some helpers that could help simplify and generalize over what Etienne did in its midi-mixer (i.e. volume faders with more complex and user friendly mappings). I left some comments in the code to explain the idea. 

What do you think? Would do the trick for most use cases?